### PR TITLE
Resolve issue with HTTP status codes /ui/login and type checks

### DIFF
--- a/abandonauth/routers/ui.py
+++ b/abandonauth/routers/ui.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Form, Request, HTTPException
@@ -319,7 +320,7 @@ async def edit_dev_application_callback_uris(
 
 
 @router.get("/login", response_class=HTMLResponse, include_in_schema=False)
-async def oauth_login(request: Request, application_id: str | None = None, callback_uri: str | None = None):
+async def oauth_login(request: Request, application_id: UUID | None = None, callback_uri: str | None = None):
     """Login for initiating the OAuth flow
 
     This page is used to start the OAuth flow for applications using AbandonAuth.
@@ -335,7 +336,7 @@ async def oauth_login(request: Request, application_id: str | None = None, callb
         )
     else:
         dev_app = await DeveloperApplication.prisma().find_unique(
-            where={"id": application_id},
+            where={"id": str(application_id)},
             include={"callback_uris": True}
         )
 

--- a/abandonauth/routers/ui.py
+++ b/abandonauth/routers/ui.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Form, Request, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from prisma.models import DeveloperApplication
-from starlette.status import HTTP_403_FORBIDDEN, HTTP_400_BAD_REQUEST, HTTP_303_SEE_OTHER
+from starlette.status import HTTP_403_FORBIDDEN, HTTP_400_BAD_REQUEST, HTTP_303_SEE_OTHER, HTTP_404_NOT_FOUND
 
 from abandonauth import templates  # type: ignore
 
@@ -342,7 +342,12 @@ async def oauth_login(request: Request, application_id: UUID | None = None, call
 
         # This check is a convenience in order to provide accurate and immediate feedback to users
         # The security check for application IDs and callback URIs must be done later in the auth flow
-        if not dev_app or not dev_app.callback_uris or callback_uri not in [x.uri for x in dev_app.callback_uris]:
+        if not dev_app:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail="Invalid application ID",
+            )
+        if not dev_app.callback_uris or callback_uri not in [x.uri for x in dev_app.callback_uris]:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN,
                 detail="Invalid application ID or callback_uri",


### PR DESCRIPTION
1. GET : https://.../ui/login?application_id=fake&callback_uri=/ui
bad application_id (not uuid) now gives 422 Unprocessable Entity, instead of 500.

2. If you will pass application_id that is existing in db, application will return 404 status code.

closes #68 