### PR TITLE
Refactor prisma commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM ghcr.io/owl-corp/python-poetry-base:3.11-slim
 
 ADD poetry.lock pyproject.toml ./
-RUN poetry install --no-root \
-    && poetry run prisma generate
+RUN poetry install --no-root
 
 WORKDIR /app
 ADD ./abandonauth ./abandonauth
 ADD ./prisma ./prisma
+RUN poetry run prisma generate
 
 EXPOSE 80
 
@@ -16,4 +16,4 @@ ARG uvicorn_extras=""
 ENV uvicorn_extras=$uvicorn_extras
 
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["poetry run prisma db push --schema prisma/schema.prisma && poetry run uvicorn abandonauth:app --host 0.0.0.0 --port 80 $uvicorn_extras"]
+CMD ["poetry run uvicorn abandonauth:app --host 0.0.0.0 --port 80 $uvicorn_extras"]


### PR DESCRIPTION
We were accidentally generating the client twice--once after installing poetry, then again when running the app. The first prisma command did nothing. It is also undesirable to run `db push` in prod (or ever) since it does not apply migrations. Instead, we should use appropriate migration commands in their respective environment.