### PR TITLE
remove httponly cookie

### DIFF
--- a/src/api/abandonauth/routers/ui.py
+++ b/src/api/abandonauth/routers/ui.py
@@ -57,7 +57,6 @@ async def index(request: Request, code: str | None = None) -> RedirectResponse:
         resp.set_cookie(
             key="Authorization",
             value=token,  # pyright: ignore [reportArgumentType]
-            httponly=True,
             secure=True
         )
 


### PR DESCRIPTION
This is not compatible with nuxt as it will prevent client-side nuxt from accessing the cookie. This results in odd behavior where the user is authenticated and requests to the backend with useFetch succeed, but client-side use of the auth cookie fails (i.e in the nuxt middleware)